### PR TITLE
Add ids to tap targets, pass last tap target when sequence is cancelled

### DIFF
--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
@@ -51,6 +51,7 @@ public class TapTarget {
 
     int titleTextSize = 20;
     int descriptionTextSize = 18;
+    int id = -1;
 
     boolean drawShadow = false;
     boolean cancelable = true;
@@ -283,6 +284,17 @@ public class TapTarget {
         }
 
         return this;
+    }
+
+    /** Specify a unique identifier for this target. **/
+    public TapTarget id(int id) {
+        this.id = id;
+        return this;
+    }
+
+    /** Return the id associated with this tap target **/
+    public int id() {
+        return id;
     }
 
     /**

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
@@ -38,7 +38,7 @@ public class TapTargetSequence {
 
     public interface Listener {
         void onSequenceFinish();
-        void onSequenceCanceled();
+        void onSequenceCanceled(TapTarget lastTarget);
     }
 
     public TapTargetSequence(Activity activity) {
@@ -112,7 +112,7 @@ public class TapTargetSequence {
                 showNext();
             } else {
                 if (listener != null) {
-                    listener.onSequenceCanceled();
+                    listener.onSequenceCanceled(view.target);
                 }
             }
         }


### PR DESCRIPTION
Fixes #50 

Adds an id field to `TapTarget` that can be used to generally identify what target was last seen when a sequence is cancelled.