### PR TITLE
Add listener to call to outer circle click

### DIFF
--- a/app/src/main/java/com/getkeepsafe/taptargetviewsample/MainActivity.java
+++ b/app/src/main/java/com/getkeepsafe/taptargetviewsample/MainActivity.java
@@ -15,6 +15,7 @@ import android.text.style.UnderlineSpan;
 import android.util.Log;
 import android.view.Display;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.getkeepsafe.taptargetview.TapTarget;
 import com.getkeepsafe.taptargetview.TapTargetSequence;
@@ -103,6 +104,12 @@ public class MainActivity extends AppCompatActivity {
                 super.onTargetClick(view);
                 // .. which evidently starts the sequence we defined earlier
                 sequence.start();
+            }
+
+            @Override
+            public void onOuterCircleClick(TapTargetView view) {
+                super.onOuterCircleClick(view);
+                Toast.makeText(view.getContext(), "Smart guy just clicked the outer circle!", Toast.LENGTH_SHORT).show();
             }
 
             @Override

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -190,6 +190,10 @@ public class TapTargetView extends View {
             view.dismiss(false);
         }
 
+        public void onOuterCircleClick(TapTargetView view) {
+            // no-op as default
+        }
+
         /**
          * Signals that the tap target has been dismissed
          * @param userInitiated Whether the user caused this action
@@ -333,11 +337,11 @@ public class TapTargetView extends View {
      * @param target The {@link TapTarget} to target
      * @param userListener Optional. The {@link Listener} instance for this view
      */
-    public TapTargetView(Context context,
-                  final ViewManager parent,
-                  @Nullable final ViewGroup boundingParent,
-                  final TapTarget target,
-                  @Nullable final Listener userListener) {
+    public TapTargetView(final Context context,
+                         final ViewManager parent,
+                         @Nullable final ViewGroup boundingParent,
+                         final TapTarget target,
+                         @Nullable final Listener userListener) {
         super(context);
         if (target == null) throw new IllegalArgumentException("Target cannot be null");
 
@@ -431,11 +435,18 @@ public class TapTargetView extends View {
             public void onClick(View v) {
                 if (listener == null || outerCircleCenter == null || !isInteractable) return;
 
-                if (targetBounds.contains((int) lastTouchX, (int) lastTouchY)) {
+                final boolean clickedInTarget = targetBounds.contains((int) lastTouchX, (int) lastTouchY);
+                final double distanceToOuterCircleCenter = distance(outerCircleCenter[0], outerCircleCenter[1],
+                                           (int) lastTouchX, (int) lastTouchY);
+                final boolean clickedInsideOfOuterCircle = distanceToOuterCircleCenter <= outerCircleRadius;
+
+                if (clickedInTarget) {
                     isInteractable = false;
                     listener.onTargetClick(TapTargetView.this);
-                } else if (cancelable && distance(outerCircleCenter[0], outerCircleCenter[1],
-                    (int) lastTouchX, (int) lastTouchY) > outerCircleRadius) {
+                } else if (clickedInsideOfOuterCircle) {
+                    listener.onOuterCircleClick(TapTargetView.this);
+                } else if (cancelable) {
+                    // click outside of outer circle
                     isInteractable = false;
                     listener.onTargetCancel(TapTargetView.this);
                 }

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -337,7 +337,7 @@ public class TapTargetView extends View {
      * @param target The {@link TapTarget} to target
      * @param userListener Optional. The {@link Listener} instance for this view
      */
-    public TapTargetView(final Context context,
+    public TapTargetView(Context context,
                          final ViewManager parent,
                          @Nullable final ViewGroup boundingParent,
                          final TapTarget target,

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -446,7 +446,6 @@ public class TapTargetView extends View {
                 } else if (clickedInsideOfOuterCircle) {
                     listener.onOuterCircleClick(TapTargetView.this);
                 } else if (cancelable) {
-                    // click outside of outer circle
                     isInteractable = false;
                     listener.onTargetCancel(TapTargetView.this);
                 }


### PR DESCRIPTION
Fixes #76 

Adds a new `Listener` method that might be overriden by the client. The current behavior (no-op) was kept as default, but now there is more flexibility for the client to customize that if needed.

Also updated the sample app.