### PR TITLE
Check width and height for every OS version

### DIFF
--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ViewUtil.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ViewUtil.java
@@ -21,19 +21,14 @@ import android.view.View;
 import android.view.ViewTreeObserver;
 
 class ViewUtil {
-    ViewUtil() {
-    }
+    ViewUtil() {}
 
-    /**
-     * Returns whether or not the view has been laid out
-     **/
+    /** Returns whether or not the view has been laid out **/
     private static boolean isLaidOut(View view) {
         return ViewCompat.isLaidOut(view) && view.getWidth() > 0 && view.getHeight() > 0;
     }
 
-    /**
-     * Executes the given {@link java.lang.Runnable} when the view is laid out
-     **/
+    /** Executes the given {@link java.lang.Runnable} when the view is laid out **/
     static void onLaidOut(final View view, final Runnable runnable) {
         if (isLaidOut(view)) {
             runnable.run();

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ViewUtil.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ViewUtil.java
@@ -16,22 +16,24 @@
 package com.getkeepsafe.taptargetview;
 
 import android.os.Build;
+import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.ViewTreeObserver;
 
 class ViewUtil {
-    ViewUtil() {}
-
-    /** Returns whether or not the view has been laid out **/
-    static boolean isLaidOut(View view) {
-        if (Build.VERSION.SDK_INT >= 19) {
-            return view.isLaidOut();
-        }
-
-        return view.getWidth() > 0 && view.getHeight() > 0;
+    ViewUtil() {
     }
 
-    /** Executes the given {@link java.lang.Runnable} when the view is laid out **/
+    /**
+     * Returns whether or not the view has been laid out
+     **/
+    private static boolean isLaidOut(View view) {
+        return ViewCompat.isLaidOut(view) && view.getWidth() > 0 && view.getHeight() > 0;
+    }
+
+    /**
+     * Executes the given {@link java.lang.Runnable} when the view is laid out
+     **/
     static void onLaidOut(final View view, final Runnable runnable) {
         if (isLaidOut(view)) {
             runnable.run();


### PR DESCRIPTION
Moving from an `if-else` way of providing backwards compatibility to the actual support library implementation through `ViewCompat`.

Even though we applied that change, it will only check for `width` and `height` pre-Kitkat (which may still cause exceptions on newer versions of the OS) so we still check those values as part of the `return` statement as a sanity check for the view being laid out.

Fixes #89