### PR TITLE
Return TapTargets in all factory methods

### DIFF
--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
@@ -85,7 +85,7 @@ public class TapTarget {
    * <p>
    * <b>Note:</b> This is currently experimental, use at your own risk
    */
-  public static ToolbarTapTarget forToolbarOverflow(Toolbar toolbar, CharSequence title) {
+  public static TapTarget forToolbarOverflow(Toolbar toolbar, CharSequence title) {
     return forToolbarOverflow(toolbar, title, null);
   }
 
@@ -93,7 +93,7 @@ public class TapTarget {
    * <p>
    * <b>Note:</b> This is currently experimental, use at your own risk
    */
-  public static ToolbarTapTarget forToolbarOverflow(Toolbar toolbar, CharSequence title,
+  public static TapTarget forToolbarOverflow(Toolbar toolbar, CharSequence title,
                                                     @Nullable CharSequence description) {
     return new ToolbarTapTarget(toolbar, false, title, description);
   }
@@ -102,7 +102,7 @@ public class TapTarget {
    * <p>
    * <b>Note:</b> This is currently experimental, use at your own risk
    */
-  public static ToolbarTapTarget forToolbarOverflow(android.widget.Toolbar toolbar, CharSequence title) {
+  public static TapTarget forToolbarOverflow(android.widget.Toolbar toolbar, CharSequence title) {
     return forToolbarOverflow(toolbar, title, null);
   }
 
@@ -110,64 +110,64 @@ public class TapTarget {
    * <p>
    * <b>Note:</b> This is currently experimental, use at your own risk
    */
-  public static ToolbarTapTarget forToolbarOverflow(android.widget.Toolbar toolbar, CharSequence title,
+  public static TapTarget forToolbarOverflow(android.widget.Toolbar toolbar, CharSequence title,
                                                     @Nullable CharSequence description) {
     return new ToolbarTapTarget(toolbar, false, title, description);
   }
 
   /** Return a tap target for the navigation button (back, up, etc) from the given toolbar **/
-  public static ToolbarTapTarget forToolbarNavigationIcon(Toolbar toolbar, CharSequence title) {
+  public static TapTarget forToolbarNavigationIcon(Toolbar toolbar, CharSequence title) {
     return forToolbarNavigationIcon(toolbar, title, null);
   }
 
   /** Return a tap target for the navigation button (back, up, etc) from the given toolbar **/
-  public static ToolbarTapTarget forToolbarNavigationIcon(Toolbar toolbar, CharSequence title,
+  public static TapTarget forToolbarNavigationIcon(Toolbar toolbar, CharSequence title,
                                                           @Nullable CharSequence description) {
     return new ToolbarTapTarget(toolbar, true, title, description);
   }
 
   /** Return a tap target for the navigation button (back, up, etc) from the given toolbar **/
-  public static ToolbarTapTarget forToolbarNavigationIcon(android.widget.Toolbar toolbar, CharSequence title) {
+  public static TapTarget forToolbarNavigationIcon(android.widget.Toolbar toolbar, CharSequence title) {
     return forToolbarNavigationIcon(toolbar, title, null);
   }
 
   /** Return a tap target for the navigation button (back, up, etc) from the given toolbar **/
-  public static ToolbarTapTarget forToolbarNavigationIcon(android.widget.Toolbar toolbar, CharSequence title,
-                                                          @Nullable CharSequence description) {
+  public static TapTarget forToolbarNavigationIcon(android.widget.Toolbar toolbar, CharSequence title,
+                                                   @Nullable CharSequence description) {
     return new ToolbarTapTarget(toolbar, true, title, description);
   }
 
   /** Return a tap target for the menu item from the given toolbar **/
-  public static ToolbarTapTarget forToolbarMenuItem(Toolbar toolbar, @IdRes int menuItemId,
-                                                    CharSequence title) {
+  public static TapTarget forToolbarMenuItem(Toolbar toolbar, @IdRes int menuItemId,
+                                             CharSequence title) {
     return forToolbarMenuItem(toolbar, menuItemId, title, null);
   }
 
   /** Return a tap target for the menu item from the given toolbar **/
-  public static ToolbarTapTarget forToolbarMenuItem(Toolbar toolbar, @IdRes int menuItemId,
-                                                    CharSequence title, @Nullable CharSequence description) {
+  public static TapTarget forToolbarMenuItem(Toolbar toolbar, @IdRes int menuItemId,
+                                             CharSequence title, @Nullable CharSequence description) {
     return new ToolbarTapTarget(toolbar, menuItemId, title, description);
   }
 
   /** Return a tap target for the menu item from the given toolbar **/
-  public static ToolbarTapTarget forToolbarMenuItem(android.widget.Toolbar toolbar, @IdRes int menuItemId,
-                                                    CharSequence title) {
+  public static TapTarget forToolbarMenuItem(android.widget.Toolbar toolbar, @IdRes int menuItemId,
+                                             CharSequence title) {
     return forToolbarMenuItem(toolbar, menuItemId, title, null);
   }
 
   /** Return a tap target for the menu item from the given toolbar **/
-  public static ToolbarTapTarget forToolbarMenuItem(android.widget.Toolbar toolbar, @IdRes int menuItemId,
+  public static TapTarget forToolbarMenuItem(android.widget.Toolbar toolbar, @IdRes int menuItemId,
                                                     CharSequence title, @Nullable CharSequence description) {
     return new ToolbarTapTarget(toolbar, menuItemId, title, description);
   }
 
   /** Return a tap target for the specified view **/
-  public static ViewTapTarget forView(View view, CharSequence title) {
+  public static TapTarget forView(View view, CharSequence title) {
     return forView(view, title, null);
   }
 
   /** Return a tap target for the specified view **/
-  public static ViewTapTarget forView(View view, CharSequence title, @Nullable CharSequence description) {
+  public static TapTarget forView(View view, CharSequence title, @Nullable CharSequence description) {
     return new ViewTapTarget(view, title, description);
   }
 

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ToolbarTapTarget.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ToolbarTapTarget.java
@@ -154,7 +154,6 @@ class ToolbarTapTarget extends ViewTapTarget {
     }
   }
 
-
   private interface ToolbarProxy {
     CharSequence getNavigationContentDescription();
 


### PR DESCRIPTION
There is no need that we return the implementations / extension. The base `TapTarget` will be enough.

On a side node: Even if we would return `ToolbarTapTarget` oder `ViewTapTarget`, we would loose this information on the first builder method call as they all return `TapTarget`