### PR TITLE
Change order of removeView and onDismiss call

### DIFF
--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -310,8 +310,8 @@ public class TapTargetView extends View {
       .onEnd(new FloatValueAnimatorBuilder.EndListener() {
         @Override
         public void onEnd() {
-          ViewUtil.removeView(parent, TapTargetView.this);
           onDismiss();
+          ViewUtil.removeView(parent, TapTargetView.this);
         }
       })
       .build();
@@ -339,8 +339,8 @@ public class TapTargetView extends View {
       .onEnd(new FloatValueAnimatorBuilder.EndListener() {
         @Override
         public void onEnd() {
-          ViewUtil.removeView(parent, TapTargetView.this);
           onDismiss();
+          ViewUtil.removeView(parent, TapTargetView.this);
         }
       })
       .build();


### PR DESCRIPTION
The value `userInitiated` of `TapTargetView.Listener.onTargetDismissed(TapTargetView, boolean)` was always `false` when I tried TapTargetView in my project.

Looking at the code it seems like it is supposed to be always `true` except when the removal of the view is *not* triggered by the end of an animation (which was triggered by a user interaction).

Changing the order of the `onDismiss()` prevents the removal of the view from triggering `onDismiss(false)`.