### PR TITLE
Catch all exceptions when removing view

### DIFF
--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ViewUtil.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ViewUtil.java
@@ -73,7 +73,7 @@ class ViewUtil {
 
     try {
       parent.removeView(child);
-    } catch (NullPointerException ignored) {
+    } catch (Exception ignored) {
       // This catch exists for modified versions of Android that have a buggy ViewGroup
       // implementation. See b.android.com/77639, #121 and #49
     }


### PR DESCRIPTION
This is a fix for https://github.com/KeepSafe/TapTargetView/issues/207

I think probably what is happening is that the view is already destroyed and removed, and we are attempting to remove it again. We could put a check in here to make sure the child is still attached to the parent before attempting to remove, but I think since we already have this needed try/catch, it might as well be made more broad to account for this. 