### PR TITLE
Add notion of isDismissing and gate onReady() callbacks on it

### DIFF
--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -430,44 +430,45 @@ public class TapTargetView extends View {
     globalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
       @Override
       public void onGlobalLayout() {
-        updateTextLayouts();
-        if (!isDismissing) {
-          target.onReady(new Runnable() {
-            @Override
-            public void run() {
-              final int[] offset = new int[2];
-
-              targetBounds.set(target.bounds());
-
-              getLocationOnScreen(offset);
-              targetBounds.offset(-offset[0], -offset[1]);
-
-              if (boundingParent != null) {
-                final WindowManager windowManager
-                    = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-                final DisplayMetrics displayMetrics = new DisplayMetrics();
-                windowManager.getDefaultDisplay().getMetrics(displayMetrics);
-
-                final Rect rect = new Rect();
-                boundingParent.getWindowVisibleDisplayFrame(rect);
-
-                // We bound the boundaries to be within the screen's coordinates to
-                // handle the case where the layout bounds do not match
-                // (like when FLAG_LAYOUT_NO_LIMITS is specified)
-                topBoundary = Math.max(0, rect.top);
-                bottomBoundary = Math.min(rect.bottom, displayMetrics.heightPixels);
-              }
-
-              drawTintedTarget();
-              requestFocus();
-              calculateDimensions();
-              if (!visible) {
-                expandAnimation.start();
-                visible = true;
-              }
-            }
-          });
+        if (isDismissing) {
+          return;
         }
+        updateTextLayouts();
+        target.onReady(new Runnable() {
+          @Override
+          public void run() {
+            final int[] offset = new int[2];
+
+            targetBounds.set(target.bounds());
+
+            getLocationOnScreen(offset);
+            targetBounds.offset(-offset[0], -offset[1]);
+
+            if (boundingParent != null) {
+              final WindowManager windowManager
+                  = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+              final DisplayMetrics displayMetrics = new DisplayMetrics();
+              windowManager.getDefaultDisplay().getMetrics(displayMetrics);
+
+              final Rect rect = new Rect();
+              boundingParent.getWindowVisibleDisplayFrame(rect);
+
+              // We bound the boundaries to be within the screen's coordinates to
+              // handle the case where the layout bounds do not match
+              // (like when FLAG_LAYOUT_NO_LIMITS is specified)
+              topBoundary = Math.max(0, rect.top);
+              bottomBoundary = Math.min(rect.bottom, displayMetrics.heightPixels);
+            }
+
+            drawTintedTarget();
+            requestFocus();
+            calculateDimensions();
+            if (!visible) {
+              expandAnimation.start();
+              visible = true;
+            }
+          }
+        });
       }
     };
 


### PR DESCRIPTION
There was a race condition I came across where a view could be animating out at the same time as the animation for dismissing the tap target. If the view animated out before the taptarget, it would trigger a layout again, and potentially redisplay the taptarget again. This gates onReady callbacks against the notion of "isDismissing". Tested locally in my project and confirmed this resolves the issue.