### PR TITLE
Fix: "Sometimes" typo in logic for Italic

### DIFF
--- a/app/src/main/java/com/getkeepsafe/taptargetviewsample/MainActivity.java
+++ b/app/src/main/java/com/getkeepsafe/taptargetviewsample/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends AppCompatActivity {
     droidTarget.offset(display.getWidth() / 2, display.getHeight() / 2);
 
     final SpannableString sassyDesc = new SpannableString("It allows you to go back, sometimes");
-    sassyDesc.setSpan(new StyleSpan(Typeface.ITALIC), sassyDesc.length() - "somtimes".length(), sassyDesc.length(), 0);
+    sassyDesc.setSpan(new StyleSpan(Typeface.ITALIC), sassyDesc.length() - "sometimes".length(), sassyDesc.length(), 0);
 
     // We have a sequence of targets, so lets build it!
     final TapTargetSequence sequence = new TapTargetSequence(this)


### PR DESCRIPTION
# Description
There is a typo in the calculations to make `sometimes` word italic in the first target of the TargetSequence, making the `s` not italic.

## Before:
<img src="https://user-images.githubusercontent.com/10025997/34999561-2bcaca1e-fac9-11e7-9b26-9f1689c3cb11.png" width="500">

## Now:
<img src="https://user-images.githubusercontent.com/10025997/34999840-f2d90382-fac9-11e7-8bda-0a28e1013312.png" width="500">

