### PR TITLE
Improvement: Add Pagination in TapTargetSequence

### DIFF
--- a/app/src/main/java/com/getkeepsafe/taptargetviewsample/MainActivity.java
+++ b/app/src/main/java/com/getkeepsafe/taptargetviewsample/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends AppCompatActivity {
     droidTarget.offset(display.getWidth() / 2, display.getHeight() / 2);
 
     final SpannableString sassyDesc = new SpannableString("It allows you to go back, sometimes");
-    sassyDesc.setSpan(new StyleSpan(Typeface.ITALIC), sassyDesc.length() - "somtimes".length(), sassyDesc.length(), 0);
+    sassyDesc.setSpan(new StyleSpan(Typeface.ITALIC), sassyDesc.length() - "sometimes".length(), sassyDesc.length(), 0);
 
     // We have a sequence of targets, so lets build it!
     final TapTargetSequence sequence = new TapTargetSequence(this)

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
@@ -82,6 +82,9 @@ public class TapTarget {
   boolean cancelable = true;
   boolean tintTarget = true;
   boolean transparentTarget = false;
+  boolean showSequencePagination = false;
+  int sequenceTargetCount = 0;
+  int sequenceCurrentTargetIndex = 0;
   float descriptionTextAlpha = 0.54f;
 
   /**

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
@@ -43,6 +43,15 @@ public class TapTargetSequence {
   Listener listener;
   boolean considerOuterCircleCanceled;
   boolean continueOnCancel;
+  boolean showSequencePagination = false;
+  int totalTargetsCount = 0;
+
+  @Nullable
+  CharSequence skipText = null;
+  @Nullable
+  CharSequence nextText = null;
+  @Nullable
+  CharSequence doneText = null;
 
   public interface Listener {
     /** Called when there are no more tap targets to display */

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
@@ -151,6 +151,7 @@ public class TapTargetSequence {
       return;
     }
 
+    if (showSequencePagination) totalTargetsCount = targets.size();
     active = true;
     showNext();
   }

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
@@ -118,6 +118,26 @@ public class TapTargetSequence {
     return this;
   }
 
+  /** Adds bullets pagination and buttons to the sequence **/
+  public TapTargetSequence showPagination(@Nullable CharSequence skipText, @Nullable CharSequence nextText, @Nullable CharSequence doneText) {
+    this.skipText = skipText;
+    this.nextText = nextText;
+    this.doneText = doneText;
+    this.showSequencePagination = true;
+    if (!targets.isEmpty()) this.totalTargetsCount = targets.size();
+    return this;
+  }
+
+  /** Removes bullets pagination and buttons to the sequence **/
+  public TapTargetSequence hidePagination() {
+    this.skipText = null;
+    this.nextText = null;
+    this.doneText = null;
+    this.showSequencePagination = false;
+    this.totalTargetsCount = 0;
+    return this;
+  }
+
   /** Specify the listener for this sequence **/
   public TapTargetSequence listener(Listener listener) {
     this.listener = listener;

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetSequence.java
@@ -222,10 +222,19 @@ public class TapTargetSequence {
   void showNext() {
     try {
       TapTarget tapTarget = targets.remove();
+
+      if (showSequencePagination) {
+        tapTarget.showSequencePagination = true;
+        tapTarget.sequenceCurrentTargetIndex = totalTargetsCount - targets.size();
+        tapTarget.sequenceTargetCount = totalTargetsCount;
+      }
+
       if (activity != null) {
-        currentView = TapTargetView.showFor(activity, tapTarget, tapTargetListener);
+        currentView = TapTargetView.showFor(activity, tapTarget, tapTargetListener,
+            this.skipText, this.nextText, this.doneText);
       } else {
-        currentView = TapTargetView.showFor(dialog, tapTarget, tapTargetListener);
+        currentView = TapTargetView.showFor(dialog, tapTarget, tapTargetListener,
+            this.skipText, this.nextText, this.doneText);
       }
     } catch (NoSuchElementException e) {
       // No more targets

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -770,6 +770,42 @@ public class TapTargetView extends View {
         paginationSecondayPaint.setAlpha((int) (target.descriptionTextAlpha * textAlpha));
         descriptionLayout.draw(c);
       }
+
+      if (target.showSequencePagination) {
+        c.translate(UiUtil.dp(getContext(), 2), 0);
+        if (descriptionLayout != null) {
+          c.translate(0, descriptionLayout.getHeight() + (TEXT_SPACING * 2));
+        } else if (titleLayout != null) {
+          c.translate(0, titleLayout.getHeight() + (TEXT_SPACING * 2));
+        }
+
+        final boolean extensiveSequence = target.sequenceTargetCount > BULLETS_MAX_NUMBERS;
+        if (!extensiveSequence) drawDefaultBullets(c, 1, target.sequenceTargetCount);
+        else drawExtensivePaginationIndicatorBullets(c);
+
+        c.translate(0, -TEXT_SPACING);
+        final int spacingBulletsTexts = BULLETS_SPACING * Math.min(target.sequenceTargetCount, BULLETS_MAX_NUMBERS);
+
+        if (target.sequenceCurrentTargetIndex < target.sequenceTargetCount) {
+          c.translate(TEXT_PADDING, 0);
+
+          if (skipLayout != null && target.cancelable) {
+            skipLayout.draw(c);
+          }
+          skipTextXPosition = textBounds.left + spacingBulletsTexts + TEXT_PADDING;
+
+          if (nextLayout != null) {
+            c.translate(nextLayout.getWidth() + TEXT_SPACING, 0);
+            nextLayout.draw(c);
+            nextTextPosition = skipTextXPosition + nextLayout.getWidth() + TEXT_SPACING;
+          }
+
+        } else if (doneLayout != null) {
+          c.translate(textBounds.right - spacingBulletsTexts - doneLayout.getWidth(), 0);
+          doneLayout.draw(c);
+          doneTextPosition = textBounds.right - doneLayout.getWidth();
+        }
+      }
     }
     c.restoreToCount(saveCount);
 
@@ -790,6 +826,42 @@ public class TapTargetView extends View {
 
     if (debug) {
       drawDebugInformation(c);
+    }
+  }
+
+  private void drawDefaultBullets(Canvas c, int initialBulletIndex, int bulletsNumber) {
+    for (int i = initialBulletIndex; i <= bulletsNumber; i++) {
+      c.drawCircle(BULLETS_PADDING, BULLETS_PADDING, BULLETS_RADIUS,
+          (i == target.sequenceCurrentTargetIndex) ? paginationMainPaint : paginationSecondayPaint);
+      c.translate(BULLETS_SPACING, 0);
+    }
+  }
+
+  private void drawExtensivePaginationIndicatorBullets(Canvas c) {
+    if (target.sequenceCurrentTargetIndex < BULLETS_MAX_NUMBERS - 3) {
+      drawDefaultBullets(c, 1, 3);
+
+      c.drawCircle(BULLETS_PADDING, BULLETS_PADDING, BULLETS_RADIUS - 1, paginationSecondayPaint);
+      c.translate(BULLETS_SPACING, 0);
+
+      c.drawCircle(BULLETS_PADDING, BULLETS_PADDING, BULLETS_RADIUS - 2, paginationSecondayPaint);
+      c.translate(BULLETS_SPACING, 0);
+    } else if (target.sequenceCurrentTargetIndex > target.sequenceTargetCount - 3) {
+      c.drawCircle(BULLETS_PADDING, BULLETS_PADDING, BULLETS_RADIUS - 2, paginationSecondayPaint);
+      c.translate(BULLETS_SPACING, 0);
+
+      c.drawCircle(BULLETS_PADDING, BULLETS_PADDING, BULLETS_RADIUS - 1, paginationSecondayPaint);
+      c.translate(BULLETS_SPACING, 0);
+
+      drawDefaultBullets(c, target.sequenceTargetCount - 2, target.sequenceTargetCount);
+    } else {
+      c.drawCircle(BULLETS_PADDING, BULLETS_PADDING, BULLETS_RADIUS - 2, paginationSecondayPaint);
+      c.translate(BULLETS_SPACING, 0);
+
+      drawDefaultBullets(c, target.sequenceCurrentTargetIndex - 1, target.sequenceCurrentTargetIndex + 1);
+
+      c.drawCircle(BULLETS_PADDING, BULLETS_PADDING, BULLETS_RADIUS - 2, paginationSecondayPaint);
+      c.translate(BULLETS_SPACING, 0);
     }
   }
 

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -536,6 +536,46 @@ public class TapTargetView extends View {
             (int) lastTouchX, (int) lastTouchY);
         final boolean clickedInsideOfOuterCircle = distanceToOuterCircleCenter <= outerCircleRadius;
 
+        if (target.showSequencePagination && clickedInsideOfOuterCircle) {
+          if (target.sequenceCurrentTargetIndex < target.sequenceTargetCount) {
+
+            int buttonHeight;
+            if (skipLayout != null && nextLayout != null) {
+              buttonHeight = Math.max(skipLayout.getHeight(), nextLayout.getHeight());
+            } else if (skipLayout != null) {
+              buttonHeight = skipLayout.getHeight();
+            } else {
+              buttonHeight = nextLayout.getHeight();
+            }
+
+            boolean clickedInSkipText = skipLayout != null &&
+                (lastTouchX > (skipTextXPosition - BUTTON_PADDING) && lastTouchX < (nextTextPosition + BUTTON_PADDING))
+                && (lastTouchY > (textBounds.bottom - buttonHeight - BUTTON_PADDING) && lastTouchY < (textBounds.bottom + BUTTON_PADDING));
+
+
+            boolean clickedInNextText = nextLayout != null &&
+                (lastTouchX > (nextTextPosition - BUTTON_PADDING) && lastTouchX < (textBounds.right + BUTTON_PADDING))
+                && (lastTouchY > (textBounds.bottom - buttonHeight - BUTTON_PADDING) && lastTouchY < (textBounds.bottom + BUTTON_PADDING));
+
+            if (clickedInNextText) {
+              isInteractable = false;
+              listener.onTargetClick(TapTargetView.this);
+            } else if (clickedInSkipText && cancelable) {
+              isInteractable = false;
+              listener.onTargetCancel(TapTargetView.this);
+            }
+          } else {
+            final boolean clickedInDoneText = doneLayout != null &&
+                (lastTouchX > (doneTextPosition - BUTTON_PADDING) && lastTouchX < (textBounds.right + BUTTON_PADDING))
+                && (lastTouchY > (textBounds.bottom - doneLayout.getHeight() - BUTTON_PADDING) && lastTouchY < (textBounds.bottom + BUTTON_PADDING));
+
+            if (clickedInDoneText) {
+              isInteractable = false;
+              listener.onTargetClick(TapTargetView.this);
+            }
+          }
+        }
+
         if (clickedInTarget) {
           isInteractable = false;
           listener.onTargetClick(TapTargetView.this);

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -1056,7 +1056,25 @@ public class TapTargetView extends View {
       return titleLayout.getHeight() + TEXT_SPACING;
     }
 
-    return titleLayout.getHeight() + descriptionLayout.getHeight() + TEXT_SPACING;
+    if (target.sequenceTargetCount == 0) {
+      return titleLayout.getHeight() + descriptionLayout.getHeight() + TEXT_SPACING;
+    }
+
+
+    int sequenceMaxHeight = 0;
+    if (target.sequenceCurrentTargetIndex < target.sequenceTargetCount) {
+      if (skipLayout != null && nextLayout != null) {
+        sequenceMaxHeight = Math.max(skipLayout.getHeight(), nextLayout.getHeight());
+      } else if (skipLayout != null) {
+        sequenceMaxHeight = skipLayout.getHeight();
+      } else {
+        sequenceMaxHeight = nextLayout.getHeight();
+      }
+    } else {
+      if (doneLayout != null) sequenceMaxHeight = doneLayout.getHeight();
+    }
+
+    return titleLayout.getHeight() + descriptionLayout.getHeight() + sequenceMaxHeight + (TEXT_SPACING * 2);
   }
 
   int getTotalTextWidth() {

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -179,13 +179,18 @@ public class TapTargetView extends View {
   }
 
   public static TapTargetView showFor(Activity activity, TapTarget target, Listener listener) {
+    return showFor(activity, target, listener, null, null, null);
+  }
+
+  public static TapTargetView showFor(Activity activity, TapTarget target, Listener listener, @Nullable CharSequence skipText, @Nullable CharSequence nextText, @Nullable CharSequence doneText) {
     if (activity == null) throw new IllegalArgumentException("Activity is null");
 
     final ViewGroup decor = (ViewGroup) activity.getWindow().getDecorView();
     final ViewGroup.LayoutParams layoutParams = new ViewGroup.LayoutParams(
         ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
     final ViewGroup content = (ViewGroup) decor.findViewById(android.R.id.content);
-    final TapTargetView tapTargetView = new TapTargetView(activity, decor, content, target, listener);
+    final TapTargetView tapTargetView = new TapTargetView(activity, decor, content, target, listener,
+        skipText, nextText, doneText);
     decor.addView(tapTargetView, layoutParams);
 
     return tapTargetView;
@@ -196,6 +201,10 @@ public class TapTargetView extends View {
   }
 
   public static TapTargetView showFor(Dialog dialog, TapTarget target, Listener listener) {
+    return showFor(dialog, target, listener, null, null, null);
+  }
+
+  public static TapTargetView showFor(Dialog dialog, TapTarget target, Listener listener, @Nullable CharSequence skipText, @Nullable CharSequence nextText, @Nullable CharSequence doneText) {
     if (dialog == null) throw new IllegalArgumentException("Dialog is null");
 
     final Context context = dialog.getContext();
@@ -210,7 +219,8 @@ public class TapTargetView extends View {
     params.width = WindowManager.LayoutParams.MATCH_PARENT;
     params.height = WindowManager.LayoutParams.MATCH_PARENT;
 
-    final TapTargetView tapTargetView = new TapTargetView(context, windowManager, null, target, listener);
+    final TapTargetView tapTargetView = new TapTargetView(context, windowManager, null, target, listener,
+        skipText, nextText, doneText);
     windowManager.addView(tapTargetView, params);
 
     return tapTargetView;
@@ -392,7 +402,10 @@ public class TapTargetView extends View {
                        final ViewManager parent,
                        @Nullable final ViewGroup boundingParent,
                        final TapTarget target,
-                       @Nullable final Listener userListener) {
+                       @Nullable final Listener userListener,
+                       @Nullable CharSequence skipText,
+                       @Nullable CharSequence nextText,
+                       @Nullable CharSequence doneText) {
     super(context);
     if (target == null) throw new IllegalArgumentException("Target cannot be null");
 

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -957,6 +957,31 @@ public class TapTargetView extends View {
     } else {
       descriptionLayout = null;
     }
+
+    if (target.showSequencePagination) {
+      if (skipText != null) {
+        skipLayout = new StaticLayout(this.skipText, paginationSecondayPaint, textWidth / 3,
+                Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
+      } else {
+        skipLayout = null;
+      }
+
+      if (nextText != null) {
+        nextLayout = new StaticLayout(this.nextText, paginationMainPaint, textWidth / 3,
+                Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
+      } else {
+        nextLayout = null;
+      }
+
+      if (doneText != null) {
+        doneLayout = new StaticLayout(this.doneText, paginationMainPaint, textWidth / 3,
+                Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
+      } else {
+        doneLayout = null;
+      }
+    } else {
+      nextLayout = null;
+    }
   }
 
   float halfwayLerp(float lerp) {

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -447,12 +447,15 @@ public class TapTargetView extends View {
     titlePaint.setTextSize(target.titleTextSizePx(context));
     titlePaint.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
     titlePaint.setAntiAlias(true);
+    paginationMainPaint = titlePaint;
+    paginationMainPaint.setTextSize(target.descriptionTextSizePx(context));
 
     descriptionPaint = new TextPaint();
     descriptionPaint.setTextSize(target.descriptionTextSizePx(context));
     descriptionPaint.setTypeface(Typeface.create(Typeface.SANS_SERIF, Typeface.NORMAL));
     descriptionPaint.setAntiAlias(true);
     descriptionPaint.setAlpha((int) (0.54f * 255.0f));
+    paginationSecondayPaint = descriptionPaint;
 
     outerCirclePaint = new Paint();
     outerCirclePaint.setAntiAlias(true);
@@ -628,23 +631,29 @@ public class TapTargetView extends View {
     final Integer titleTextColor = target.titleTextColorInt(context);
     if (titleTextColor != null) {
       titlePaint.setColor(titleTextColor);
+      paginationMainPaint.setColor(titleTextColor);
     } else {
       titlePaint.setColor(isDark ? Color.BLACK : Color.WHITE);
+      paginationMainPaint.setColor(isDark ? Color.BLACK : Color.WHITE);
     }
 
     final Integer descriptionTextColor = target.descriptionTextColorInt(context);
     if (descriptionTextColor != null) {
       descriptionPaint.setColor(descriptionTextColor);
+      paginationSecondayPaint.setColor(descriptionTextColor);
     } else {
       descriptionPaint.setColor(titlePaint.getColor());
+      paginationSecondayPaint.setColor(titlePaint.getColor());
     }
 
     if (target.titleTypeface != null) {
       titlePaint.setTypeface(target.titleTypeface);
+      paginationMainPaint.setTypeface(target.titleTypeface);
     }
 
     if (target.descriptionTypeface != null) {
       descriptionPaint.setTypeface(target.descriptionTypeface);
+      paginationSecondayPaint.setTypeface(target.descriptionTypeface);
     }
   }
 
@@ -710,6 +719,7 @@ public class TapTargetView extends View {
     {
       c.translate(textBounds.left, textBounds.top);
       titlePaint.setAlpha(textAlpha);
+      paginationMainPaint.setAlpha(textAlpha);
       if (titleLayout != null) {
         titleLayout.draw(c);
       }
@@ -717,6 +727,7 @@ public class TapTargetView extends View {
       if (descriptionLayout != null && titleLayout != null) {
         c.translate(0, titleLayout.getHeight() + TEXT_SPACING);
         descriptionPaint.setAlpha((int) (target.descriptionTextAlpha * textAlpha));
+        paginationSecondayPaint.setAlpha((int) (target.descriptionTextAlpha * textAlpha));
         descriptionLayout.draw(c);
       }
     }

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -415,6 +415,9 @@ public class TapTargetView extends View {
     this.listener = userListener != null ? userListener : new Listener();
     this.title = target.title;
     this.description = target.description;
+    this.skipText = skipText;
+    this.nextText = nextText;
+    this.doneText = doneText;
 
     TARGET_PADDING = UiUtil.dp(context, 20);
     CIRCLE_PADDING = UiUtil.dp(context, 40);
@@ -427,10 +430,18 @@ public class TapTargetView extends View {
     SHADOW_DIM = UiUtil.dp(context, 8);
     SHADOW_JITTER_DIM = UiUtil.dp(context, 1);
     TARGET_PULSE_RADIUS = (int) (0.1f * TARGET_RADIUS);
+    BUTTON_PADDING = UiUtil.dp(context, 8);
+    BULLETS_MAX_NUMBERS = 5;
+    BULLETS_PADDING = UiUtil.dp(getContext(), 4);
+    BULLETS_SPACING = UiUtil.dp(getContext(), 12);
+    BULLETS_RADIUS = UiUtil.dp(getContext(), 4);
 
     outerCirclePath = new Path();
     targetBounds = new Rect();
     drawingBounds = new Rect();
+    skipTextXPosition = 0;
+    nextTextPosition = 0;
+    doneTextPosition = 0;
 
     titlePaint = new TextPaint();
     titlePaint.setTextSize(target.titleTextSizePx(context));

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -82,6 +82,11 @@ public class TapTargetView extends View {
   final int GUTTER_DIM;
   final int SHADOW_DIM;
   final int SHADOW_JITTER_DIM;
+  final int BUTTON_PADDING;
+  final int BULLETS_MAX_NUMBERS;
+  final int BULLETS_PADDING;
+  final int BULLETS_SPACING;
+  final int BULLETS_RADIUS;
 
   @Nullable
   final ViewGroup boundingParent;
@@ -91,6 +96,8 @@ public class TapTargetView extends View {
 
   final TextPaint titlePaint;
   final TextPaint descriptionPaint;
+  final TextPaint paginationMainPaint;
+  final TextPaint paginationSecondayPaint;
   final Paint outerCirclePaint;
   final Paint outerCircleShadowPaint;
   final Paint targetCirclePaint;
@@ -103,6 +110,18 @@ public class TapTargetView extends View {
   CharSequence description;
   @Nullable
   StaticLayout descriptionLayout;
+  @Nullable
+  CharSequence skipText;
+  @Nullable
+  StaticLayout skipLayout;
+  @Nullable
+  CharSequence nextText;
+  @Nullable
+  StaticLayout nextLayout;
+  @Nullable
+  CharSequence doneText;
+  @Nullable
+  StaticLayout doneLayout;
   boolean isDark;
   boolean debug;
   boolean shouldTintTarget;
@@ -144,6 +163,9 @@ public class TapTargetView extends View {
 
   int topBoundary;
   int bottomBoundary;
+  int skipTextXPosition;
+  int nextTextPosition;
+  int doneTextPosition;
 
   Bitmap tintedTarget;
 


### PR DESCRIPTION
# Introduction
Hello!

First of all, **thanks a lot** for your lib, it is amazing!

I am developing an app where the designer requested an Onboarding like this:
<h3 align="center">
<img src="https://user-images.githubusercontent.com/10025997/35000700-378496ca-facc-11e7-8e1f-fc85a8f56949.png" width="400">
</h3>

Also, in the last target of the sequence it changes the `SKIP TOUR` and `NEXT` to just a `DONE`.
With your lib I could achieve almost all the requirements, but the pagination with bullets and the "buttons" were missing...

This is what this PR is about.

# Description
I develop this pagination with bullets and buttons having in mind that, in the worst scenario, it will draw 3 components (considering all the bullets as 1 component).

With this mindset, the buttons haves 1/3 of the text width.

Since the sequence can have a lot of targets, the pagination bullets could override the buttons drawing, so I limited it in 5 bullets. Maybe this number is not the optimal and allow the user set it could be a better option, but it worked very well for me.
If the sequence haves more than 5 targets, the bullets are drawn in a way to let the user knows that are more steps, similar to the Instagram approach when someone sends a lot of pictures in one post.

I also implemented it in a way that the user can start the pagination during the initialisation of the TapTargetSequence variable or later. Also, he can hide it and restart the pagination with other texts.

I added two TextPaints variables (`paginationMainPaint` for the current target bullet and the Next/Done button, and `paginationSecondaryPaint` for the other bullets and for the Skip button) so the user can set/change it with only more some lines of code (create the variables and functions to do that in the TapTargetSequence and TapTarget classes).

# Before:
<h3 align="center">
<img src="https://user-images.githubusercontent.com/10025997/35003189-2d510f06-fad3-11e7-880c-01c0c1677934.gif" width="280" height="498" alt="Video 1"/>
</h3>

# Now:

Adding in the line 48 of MainActivity of the Sample app this command `.showPagination("SKIP", "NEXT", "DONE")`.
This is an example of sequence until the end with pagination:
<h3 align="center">
<img src="https://user-images.githubusercontent.com/10025997/35003054-c05c1a76-fad2-11e7-87c9-5f4edfa9cea8.gif" width="280" height="498" alt="Pagination until Done">
</h3>
And this is an example of sequence skipping in one of the targets:
<h3 align="center">
<img src="https://user-images.githubusercontent.com/10025997/35003364-c4434956-fad3-11e7-9119-b5b230416a19.gif" width="280" height="498" alt="Pagination Skip">
</h3>


