### PR TITLE
Use api configuration for public dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }
 

--- a/taptargetview/build.gradle
+++ b/taptargetview/build.gradle
@@ -17,9 +17,9 @@ android {
 
 def supportLibraryVersion = '27.0.2'
 dependencies {
-    implementation "com.android.support:support-annotations:$supportLibraryVersion"
+    api "com.android.support:support-annotations:$supportLibraryVersion"
+    api "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:support-compat:$supportLibraryVersion"
-    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
 }
 
 install {


### PR DESCRIPTION
Some support annotations and the v7 support Toolbar are both part of the
public api, so they need to be specified as `api` in order for them to
transitively picked up by downstream dependents.

I also updated the plugin dependencies, since the maven plugin 1.5 doesn't work with gradle 4.1.