### PR TITLE
use central build variables

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion defCompileSdkVersion
+    buildToolsVersion defBuildToolsVersion
 
     defaultConfig {
         applicationId "com.getkeepsafe.taptargetviewsample"
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     implementation project(':taptargetview')
-    implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation 'com.android.support:design:27.0.2'
+    implementation "com.android.support:appcompat-v7:$defSupportLibraryVersion"
+    implementation "com.android.support:design:$defSupportLibraryVersion"
     implementation 'com.facebook.stetho:stetho:1.5.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,14 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
     }
+}
+
+ext {
+    defBuildToolsVersion = "27.0.3"
+    defSupportLibraryVersion = '27.0.2'
+    defCompileSdkVersion = 27
 }
 
 allprojects {

--- a/taptargetview/build.gradle
+++ b/taptargetview/build.gradle
@@ -8,18 +8,18 @@ version = '1.11.0'
 description = 'An implementation of tap targets from the Material Design guidelines for feature discovery'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion defCompileSdkVersion
+    buildToolsVersion defBuildToolsVersion
 
     defaultConfig {
         minSdkVersion 14
     }
 }
 
-def supportLibraryVersion = '27.0.2'
 dependencies {
-    api "com.android.support:support-annotations:$supportLibraryVersion"
-    api "com.android.support:appcompat-v7:$supportLibraryVersion"
-    implementation "com.android.support:support-compat:$supportLibraryVersion"
+    api "com.android.support:support-annotations:$defSupportLibraryVersion"
+    api "com.android.support:appcompat-v7:$defSupportLibraryVersion"
+    implementation "com.android.support:support-compat:$defSupportLibraryVersion"
 }
 
 install {


### PR DESCRIPTION
It still annoys me with "Install build tools 26.0.2" because buildToolsVersion is missing in module `taptargetview` 

* in module "taptargetview" buildToolsVersion was missing und request an install of 26.0.2
* variable SupportLibraryVersion was just in one module