### PR TITLE
Option to disable pulse animation of the target

### DIFF
--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
@@ -83,6 +83,7 @@ public class TapTarget {
   boolean tintTarget = true;
   boolean transparentTarget = false;
   float descriptionTextAlpha = 0.54f;
+  boolean pulseEnabled = true;
 
   /**
    * Return a tap target for the overflow button from the given toolbar
@@ -376,6 +377,13 @@ public class TapTarget {
     this.drawShadow = draw;
     return this;
   }
+
+  /** Specify whether or not the target circle should pulsate **/
+  public TapTarget pulse(boolean status) {
+    this.pulseEnabled = status;
+    return this;
+  }
+
 
   /** Specify whether or not the target should be cancelable **/
   public TapTarget cancelable(boolean status) {

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -272,7 +272,9 @@ public class TapTargetView extends View {
       .onEnd(new FloatValueAnimatorBuilder.EndListener() {
         @Override
         public void onEnd() {
-          pulseAnimation.start();
+          if(target.pulseEnabled) {
+            pulseAnimation.start();
+          }
           isInteractable = true;
         }
       })


### PR DESCRIPTION
Adds an option to TapTarget to disable the pulse animation around the target circle.