### PR TITLE
Don't tint transparent targets

### DIFF
--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -541,7 +541,7 @@ public class TapTargetView extends View {
   }
 
   protected void applyTargetOptions(Context context) {
-    shouldTintTarget = target.tintTarget;
+    shouldTintTarget = !target.transparentTarget && target.tintTarget;
     shouldDrawShadow = target.drawShadow;
     cancelable = target.cancelable;
 


### PR DESCRIPTION
When transparentTarget(true) is specified, we shouldn't be creating a
tinted bitmap. Doing so wastes memory and in Android P shows a
rectangular artifact whilst the target circle is expanding.

Fixes #313