### PR TITLE
Move artifact publishing from JCenter to Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+<!--
+
+Prepend the changelog with this template on every release.
+
+# [Unreleased]
+- Changes (<PR #>)
+
+-->
+
+## [Unreleased]
+- Moved artifact publishing from JCenter to Maven Central

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ Prepend the changelog with this template on every release.
 -->
 
 ## [Unreleased]
-- Moved artifact publishing from JCenter to Maven Central
+- Moved artifact publishing from JCenter to Maven Central (#385)

--- a/README.md
+++ b/README.md
@@ -6,28 +6,32 @@
     TapTargetView
 </h1>
 
-[![Download](https://api.bintray.com/packages/keepsafesoftware/Android/TapTargetView/images/download.svg) ](https://bintray.com/keepsafesoftware/Android/TapTargetView/_latestVersion)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.getkeepsafe.taptargetview/taptargetview/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.getkeepsafe.taptargetview/taptargetview)
+[![Release](https://img.shields.io/github/tag/KeepSafe/TapTargetView.svg?label=jitpack)](https://jitpack.io/#KeepSafe/TapTargetView)
 
 
 An implementation of tap targets from [Google's Material Design guidelines on feature discovery](https://material.io/archive/guidelines/growth-communications/feature-discovery.html).
 
-**Min SDK:** 14
+ **Min SDK:** 14
+
+ [JavaDoc](https://javadoc.jitpack.io/com/github/KeepSafe/TapTargetView/latest/javadoc/)
 
 ## Installation
 
-TapTargetView is distributed using [jcenter](https://bintray.com/keepsafesoftware/Android/TapTargetView/view).
+TapTargetView is distributed using [MavenCentral](https://search.maven.org/artifact/com.getkeepsafe.taptargetview/taptargetview).
 
 ```groovy
    repositories { 
-        jcenter()
+        mavenCentral()
    }
    
    dependencies {
-         implementation 'com.getkeepsafe.taptargetview:taptargetview:1.13.0'
+         implementation 'com.getkeepsafe.taptargetview:taptargetview:1.13.1'
    }
 ```
 
-If you wish to use a snapshot, please follow the instructions [here](https://jitpack.io/#KeepSafe/TapTargetView/-SNAPSHOT)
+If you wish, you may also use TapTargetView with [jitpack](https://jitpack.io/#KeepSafe/TapTargetView).
+For snapshots, please follow the instructions [here](https://jitpack.io/#KeepSafe/TapTargetView/-SNAPSHOT).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ TapTargetView is distributed using [MavenCentral](https://search.maven.org/artif
    }
    
    dependencies {
-         implementation 'com.getkeepsafe.taptargetview:taptargetview:1.13.0'
+         implementation 'com.getkeepsafe.taptargetview:taptargetview:x.x.x'
    }
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ TapTargetView is distributed using [MavenCentral](https://search.maven.org/artif
    }
    
    dependencies {
-         implementation 'com.getkeepsafe.taptargetview:taptargetview:1.13.1'
+         implementation 'com.getkeepsafe.taptargetview:taptargetview:1.13.0'
    }
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,71 @@
+How To Release
+==============
+
+Due to Maven Central's very particular requirements, the release process is a bit
+elaborate and requires a good deal of local configuration. This guide should walk
+you through it. It won't do anyone outside of KeepSafe any good, but the workflow
+is representative of just about any project deploying via Sonatype.
+
+We currently deploy to Maven Central (via Sonatype's OSS Nexus instance).
+
+### Prerequisites
+
+1. A *published* GPG code-signing key
+1. A Sonatype Nexus OSS account with permission to publish in com.getkeepsafe
+1. Permission to push directly to https://github.com/KeepSafe/TapTargetView
+
+### Setup
+
+1. Add your GPG key to your github profile - this is required
+   for github to know that your commits and tags are "verified".
+1. Configure your code-signing key in ~/.gradle.properties:
+   ```gradle
+   signing.keyId=<key ID of your GPG signing key>
+   signing.password=<your key's passphrase>
+   signing.secretKeyRingFile=/path/to/your/secring.gpg
+   ```
+1. Configure your Sonatype credentials in ~/.gradle.properties:
+   ```gradle
+   SONATYPE_NEXUS_USERNAME=<nexus username>
+   SONATYPE_NEXUS_PASSWORD=<nexus password>
+   ```
+1. Configure git with your codesigning key; make sure it's the same as the one
+   you use to sign binaries (i.e. it's the same one you added to gradle.properties):
+   ```bash
+   # Do this for the TapTargetView repo only
+   git config user.email "your@email.com"
+   git config user.signingKey "your-key-id"
+   ```
+
+### Pushing a build
+
+1. Edit gradle.properties, update the VERSION property for the new version release
+1. Edit readme so that Gradle examples point to the new version
+1. Edit changelog, add relevant changes, note the date and new version (follow the existing pattern)
+1. Add new `## [Unreleased]` header for next release
+1. Verify that the everything works:
+   ```bash
+   ./gradlew clean check
+   ```
+1. Make a *signed* commit:
+   ```bash
+   git commit -S -m "Release version X.Y.Z"
+   ```
+1. Make a *signed* tag:
+   ```bash
+   git tag -s -a X.Y.Z
+   ```
+1. Upload binaries to Sonatype:
+   ```bash
+   ./gradlew publish
+   ```
+1. Go to [Sonatype](https://oss.sonatype.org/), log in with your credentials
+1. Click "Staging Repositories"
+1. Find the "comgetkeepsafe" repo, usually at the bottom of the list
+1. "Close" the repository (select it then click the "close" button up top), the text field doesn't matter so put whatever you want in it
+1. Wait until that's done
+1. "Release" the repository, leave the checkbox checked.  Hooray, we're in Maven Central now!
+1. Push all of our work to Github to make it official. Check previous [releases](https://github.com/KeepSafe/TapTargetView/releases) and edit tag release changes:
+   ```bash
+   git push --tags origin master
+   ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,7 +40,6 @@ We currently deploy to Maven Central (via Sonatype's OSS Nexus instance).
 ### Pushing a build
 
 1. Edit gradle.properties, update the VERSION property for the new version release
-1. Edit readme so that Gradle examples point to the new version
 1. Edit changelog, add relevant changes, note the date and new version (follow the existing pattern)
 1. Add new `## [Unreleased]` header for next release
 1. Verify that the everything works:

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,6 +49,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="end|bottom"
             android:layout_marginBottom="50dp"
+            android:layout_marginRight="16dp"
             android:layout_marginEnd="16dp"
             android:src="@drawable/ic_directions_car_black_24dp"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'
     }
 }
 
@@ -20,8 +21,12 @@ ext {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
+        // TODO: Remove this repository when Android build tools no longer transitively pulls
+        //  `trove4j` or if it's properly published in Maven Central when JCenter goes away.
+        //  See: https://github.com/KeepSafe/ReLinker/pull/81#issuecomment-787525670
+        gradlePluginPortal()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,25 @@
 android.enableJetifier=true
 android.useAndroidX=true
+
+GROUP=com.getkeepsafe.taptargetview
+VERSION_NAME=1.13.1
+POM_ARTIFACT_ID=taptargetview
+
+POM_NAME=TapTargetView
+POM_PACKAGING=aar
+
+POM_DESCRIPTION=An implementation of tap targets from the Material Design guidelines for feature discovery
+POM_INCEPTION_YEAR=2016
+
+POM_URL=https://github.com/KeepSafe/TapTargetView
+POM_SCM_URL=https://github.com/KeepSafe/TapTargetView
+POM_SCM_CONNECTION=scm:git:git://github.com/KeepSafe/TapTargetView.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com:KeepSafe/TapTargetView.git
+
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=keepsafe
+POM_DEVELOPER_NAME=KeepSafe Software, Inc.
+POM_DEVELOPER_URL=https://github.com/KeepSafe/

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ android.enableJetifier=true
 android.useAndroidX=true
 
 GROUP=com.getkeepsafe.taptargetview
-VERSION_NAME=1.13.1
+VERSION_NAME=1.13.0
 POM_ARTIFACT_ID=taptargetview
 
 POM_NAME=TapTargetView

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ android.enableJetifier=true
 android.useAndroidX=true
 
 GROUP=com.getkeepsafe.taptargetview
-VERSION_NAME=1.13.0
+VERSION_NAME=1.13.1
 POM_ARTIFACT_ID=taptargetview
 
 POM_NAME=TapTargetView

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/taptargetview/build.gradle
+++ b/taptargetview/build.gradle
@@ -1,11 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
-
-def libname = 'TapTargetView'
-group = 'com.getkeepsafe.taptargetview'
-version = '1.13.0'
-description = 'An implementation of tap targets from the Material Design guidelines for feature discovery'
+apply plugin: 'com.vanniktech.maven.publish'
 
 android {
     compileSdkVersion defCompileSdkVersion
@@ -20,59 +15,6 @@ dependencies {
     api "androidx.annotation:annotation:$defAndroidXVersion"
     api "androidx.appcompat:appcompat:$defAndroidXVersion"
     implementation "androidx.core:core:$defAndroidXVersion"
-}
-
-install {
-    repositories.mavenInstaller {
-        pom.project {
-            name libname
-            description project.description
-            url "https://github.com/KeepSafe/$libname"
-            inceptionYear 2016
-
-            packaging 'aar'
-            groupId project.group
-            artifactId 'taptargetview'
-            version project.version
-
-            licenses {
-                license {
-                    name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    distribution 'repo'
-                }
-            }
-            scm {
-                connection "https://github.com/KeepSafe/${libname}.git"
-                url "https://github.com/KeepSafe/$libname"
-            }
-            developers {
-                developer {
-                    name 'Keepsafe'
-                }
-            }
-        }
-    }
-}
-
-bintray {
-    user = project.hasProperty('bintray.user') ? project.property('bintray.user') : ''
-    key = project.hasProperty('bintray.apikey') ? project.property('bintray.apikey') : ''
-    configurations = ['archives']
-    pkg {
-        repo = 'Android'
-        name = libname
-        userOrg = 'keepsafesoftware'
-        licenses = ['Apache-2.0']
-        vcsUrl = "https://github.com/KeepSafe/${libname}.git"
-
-        version {
-            name = project.version
-            desc = project.description
-            released = new Date()
-            vcsTag = project.version
-        }
-    }
 }
 
 // build a jar with source files

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ToolbarTapTarget.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/ToolbarTapTarget.java
@@ -18,9 +18,6 @@ package com.getkeepsafe.taptargetview;
 import android.annotation.TargetApi;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import androidx.annotation.IdRes;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
@@ -29,6 +26,10 @@ import android.widget.ImageView;
 
 import java.util.ArrayList;
 import java.util.Stack;
+
+import androidx.annotation.IdRes;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
 
 class ToolbarTapTarget extends ViewTapTarget {
   ToolbarTapTarget(Toolbar toolbar, @IdRes int menuItemId,
@@ -58,7 +59,8 @@ class ToolbarTapTarget extends ViewTapTarget {
 
     if (instance instanceof Toolbar) {
       return new SupportToolbarProxy((Toolbar) instance);
-    } else if (instance instanceof android.widget.Toolbar) {
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+            && instance instanceof android.widget.Toolbar) {
       return new StandardToolbarProxy((android.widget.Toolbar) instance);
     }
 


### PR DESCRIPTION
This PR addresses https://github.com/KeepSafe/TapTargetView/issues/384 and https://github.com/KeepSafe/TapTargetView/issues/379. 

Changes:
* Move artifact publishing from JCenter to Maven Central
* Added `CHANGELOG.md` file
* Added `RELEASING.md` guide for Keepsafe employees

Maven Central version will start from `1.13.2`.

Thanks to:
* @hannesvoss, @entibaldi