### PR TITLE
Remove all jcenter dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Prepend the changelog with this template on every release.
 -->
 
 ## [Unreleased]
+- Removed JCenter dependencies and updated other build dependencies (#388)
 
 ## [1.13.2] - Released March 10, 2021
 - Moved artifact publishing from JCenter to Maven Central (#385)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,8 +26,8 @@ We currently deploy to Maven Central (via Sonatype's OSS Nexus instance).
    ```
 1. Configure your Sonatype credentials in ~/.gradle/gradle.properties:
    ```gradle
-   SONATYPE_NEXUS_USERNAME=<nexus username>
-   SONATYPE_NEXUS_PASSWORD=<nexus password>
+   mavenCentralUsername=<nexus username>
+   mavenCentralPassword=<nexus password>
    SONATYPE_STAGING_PROFILE=com.getkeepsafe
    ```
 1. Configure git with your codesigning key; make sure it's the same as the one

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion defCompileSdkVersion
-    buildToolsVersion defBuildToolsVersion
 
     defaultConfig {
         applicationId 'com.getkeepsafe.taptargetviewsample'
@@ -21,7 +20,7 @@ android {
 
 dependencies {
     implementation project(':taptargetview')
-    implementation "androidx.appcompat:appcompat:$defAndroidXVersion"
+    implementation "androidx.appcompat:appcompat:$defAppCompatVersion"
     implementation "com.google.android.material:material:$defMaterialVersion"
     implementation 'com.facebook.stetho:stetho:1.5.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,20 +2,19 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.17.0'
     }
 }
 
 ext {
-    defBuildToolsVersion = '28.0.2'
-    defAndroidXVersion = '1.0.0'
-    defMaterialVersion = '1.0.0'
-    defCompileSdkVersion = 28
+    defAndroidXCoreVersion = '1.6.0'
+    defAndroidAnnotationVersion = '1.2.0'
+    defAppCompatVersion = '1.3.0'
+    defMaterialVersion = '1.4.0'
+    defCompileSdkVersion = 30
     defMinSdkVersion = 14
 }
 
@@ -23,10 +22,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        // TODO: Remove this repository when Android build tools no longer transitively pulls
-        //  `trove4j` or if it's properly published in Maven Central when JCenter goes away.
-        //  See: https://github.com/KeepSafe/ReLinker/pull/81#issuecomment-787525670
-        gradlePluginPortal()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/taptargetview/build.gradle
+++ b/taptargetview/build.gradle
@@ -1,20 +1,19 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.vanniktech.maven.publish'
 
 android {
     compileSdkVersion defCompileSdkVersion
-    buildToolsVersion defBuildToolsVersion
 
     defaultConfig {
         minSdkVersion defMinSdkVersion
+        targetSdkVersion defCompileSdkVersion
     }
 }
 
 dependencies {
-    api "androidx.annotation:annotation:$defAndroidXVersion"
-    api "androidx.appcompat:appcompat:$defAndroidXVersion"
-    implementation "androidx.core:core:$defAndroidXVersion"
+    api "androidx.annotation:annotation:$defAndroidAnnotationVersion"
+    api "androidx.appcompat:appcompat:$defAppCompatVersion"
+    implementation "androidx.core:core:$defAndroidXCoreVersion"
 }
 
 // build a jar with source files


### PR DESCRIPTION
This PR removes JCenter dependencies similar to https://github.com/KeepSafe/ReLinker/pull/87

Changes:
* Updated other build dependencies to latest version
* Updated Releasing guide for changed maven publishing gradle property keys

Demo for validating update changes:
https://user-images.githubusercontent.com/2557303/125117725-7c062280-e0a3-11eb-8295-a3c21a309d43.mp4

Note: This will be published to MavenCentral for version `1.13.3`