### PR TITLE
Support Force Centered Target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Prepend the changelog with this template on every release.
 -->
 
 # [Unreleased]
+- Added attribute for force centering tap targets (#409)
 
 ## [1.14.0] - Released August 16, 2024
 - Modernize project build files (#407)

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTarget.java
@@ -87,6 +87,8 @@ public class TapTarget {
   boolean drawBehindStatusBar = true;
   boolean drawBehindNavigationBar = true;
 
+  boolean forceCenteredTarget = false;
+
   /**
    * Return a tap target for the overflow button from the given toolbar
    * <p>
@@ -215,6 +217,12 @@ public class TapTarget {
   /** Specify whether the target should draw behind the navigation bar. */
   public TapTarget setDrawBehindNavigationBar(boolean drawBehindNavigationBar) {
     this.drawBehindNavigationBar = drawBehindNavigationBar;
+    return this;
+  }
+
+  /** Specify whether the target should be forced to center on the target view.  */
+  public TapTarget setForceCenteredTarget(boolean forceCenteredTarget) {
+    this.forceCenteredTarget = forceCenteredTarget;
     return this;
   }
 

--- a/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
+++ b/taptargetview/src/main/java/com/getkeepsafe/taptargetview/TapTargetView.java
@@ -972,7 +972,7 @@ public class TapTargetView extends View {
   }
 
   int[] getOuterCircleCenterPoint() {
-    if (inGutter(targetBounds.centerY())) {
+    if (inGutter(targetBounds.centerY()) || target.forceCenteredTarget) {
       return new int[]{targetBounds.centerX(), targetBounds.centerY()};
     }
 


### PR DESCRIPTION
Adds `setForceCenteredTarget(boolean)` method to TapTarget.

Before, a target would only be centered if the library detected the target view is in "the gutter", which means the target views center Y is within 88dp of the content bounding rects top or bottom. We should allow the user to configure this behavior to be enabled manually.

Old behavior with FAB 59dp from bottom (`59 + fabHeight / 2 = 87dp`):
<img src="https://github.com/user-attachments/assets/92f4ed1e-63d0-4a31-898d-b175f0632db0" width="150" />

Old behavior with FAB 60dp from bottom (`60 + fabHeight / 2 = 88dp`):
<img src="https://github.com/user-attachments/assets/f123b600-8b92-40e6-b88e-15c043f5bac0" width="150" />

After allowing the user to force center the tap target with FAB 120dp from bottom:
<img src="https://github.com/user-attachments/assets/fb1b96ab-0864-472d-a66d-0c1a0de6a26d" width="150" />
